### PR TITLE
Display search item details

### DIFF
--- a/starwarsapp/package-lock.json
+++ b/starwarsapp/package-lock.json
@@ -10635,6 +10635,11 @@
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
+    "lodash.shuffle": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
+      "integrity": "sha1-FFtQU8+HX29cKjP0i26ZSMbse0s="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npm.taobao.org/lodash.sortby/download/lodash.sortby-4.7.0.tgz",

--- a/starwarsapp/package.json
+++ b/starwarsapp/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^0.21.0",
     "core-js": "^3.6.5",
+    "lodash.shuffle": "^4.2.0",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0"

--- a/starwarsapp/src/api/search.js
+++ b/starwarsapp/src/api/search.js
@@ -16,9 +16,14 @@ function getMoviesById (id) {
   return client.get(`/movies/${id}`)
 }
 
+function get (path) {
+  return client.get(path)
+}
+
 export default {
   getPeopleByName,
   getPeopleById,
   getMoviesByName,
-  getMoviesById
+  getMoviesById,
+  get
 }

--- a/starwarsapp/src/api/search.js
+++ b/starwarsapp/src/api/search.js
@@ -1,10 +1,10 @@
 import client from './client'
 
-function getPersonByName (name) {
+function getPeopleByName (name) {
   return client.get('/people', { params: { search: name } })
 }
 
-function getPersonById (id) {
+function getPeopleById (id) {
   return client.get(`/people/${id}`)
 }
 
@@ -17,8 +17,8 @@ function getMoviesById (id) {
 }
 
 export default {
-  getPersonByName,
-  getPersonById,
+  getPeopleByName,
+  getPeopleById,
   getMoviesByName,
   getMoviesById
 }

--- a/starwarsapp/src/api/search.js
+++ b/starwarsapp/src/api/search.js
@@ -1,14 +1,24 @@
 import client from './client'
 
-function getPerson (name) {
+function getPersonByName (name) {
   return client.get('/people', { params: { search: name } })
 }
 
-function getMovies (name) {
+function getPersonById (id) {
+  return client.get(`/people/${id}`)
+}
+
+function getMoviesByName (name) {
   return client.get('/movies', { params: { search: name } })
 }
 
+function getMoviesById (id) {
+  return client.get(`/movies/${id}`)
+}
+
 export default {
-  getPerson,
-  getMovies
+  getPersonByName,
+  getPersonById,
+  getMoviesByName,
+  getMoviesById
 }

--- a/starwarsapp/src/api/search.js
+++ b/starwarsapp/src/api/search.js
@@ -9,11 +9,11 @@ function getPeopleById (id) {
 }
 
 function getMoviesByName (name) {
-  return client.get('/movies', { params: { search: name } })
+  return client.get('/films', { params: { search: name } })
 }
 
 function getMoviesById (id) {
-  return client.get(`/movies/${id}`)
+  return client.get(`/films/${id}`)
 }
 
 function get (path) {

--- a/starwarsapp/src/assets/stylesheets/common/_layout.scss
+++ b/starwarsapp/src/assets/stylesheets/common/_layout.scss
@@ -117,7 +117,11 @@ $spaceings: (
     }
     
     .align-start {
-    align-items: flex-start;
+        align-items: flex-start;
+    }
+
+    .align-end {
+        align-items: flex-end;
     }
     
     .align-stretch {

--- a/starwarsapp/src/components/details/DetialsPanel.vue
+++ b/starwarsapp/src/components/details/DetialsPanel.vue
@@ -1,9 +1,16 @@
 <template>
   <div class="details-panel flex-v align-start justify-space-between box-shadow pa-xl">
     <span class="name">{{ name }}</span>
-    <div class="details-panel-content flex-h align-start justify-space-between">
+    <div v-if="notFilm" class="details-panel-content flex-h align-start justify-space-between">
       <result-details class="mt-xl" v-if="itemDetails" :details="itemDetails"/>
       <related-results class="mt-xl" :relevant="relevant" />
+    </div>
+    <div v-else class="details-film-panel flex-v algin-center">
+      <span v-if="openingCrawl" class="opening-crawl mt-l">{{ openingCrawl }}</span>
+      <div class="details-film-panel-content flex-h align-start justify-space-between">
+        <result-details class="mt-xl" v-if="itemDetails" :details="itemDetails"/>
+        <related-results class="mt-xl" :relevant="relevant" />
+      </div>
     </div>
     <base-button class="px-m mt-m" text="Go Back" @click="$router.push({ name: 'Home' })" />
   </div>
@@ -21,6 +28,10 @@ export default {
       type: String,
       required: true
     },
+    openingCrawl: {
+      type: String,
+      default: ''
+    },
     relevant: {
       type: Array,
       default: () => ([])
@@ -30,8 +41,8 @@ export default {
       default: () => ([])
     }
   },
-  created () {
-    console.log(this.relevant)
+  computed: {
+    notFilm: vm => vm.$route.params.type !== 'films'
   },
   components: {
     ResultDetails,
@@ -48,6 +59,13 @@ export default {
 
   &-content {
     width: 100%;
+  }
+
+  .details-film-panel {
+    .opening-crawl {
+      color: var(--color-grey-dimm);
+      text-align: initial;
+    }
   }
 
   .name {

--- a/starwarsapp/src/components/details/DetialsPanel.vue
+++ b/starwarsapp/src/components/details/DetialsPanel.vue
@@ -3,9 +3,9 @@
     <span class="name">{{ name }}</span>
     <div class="details-panel-content flex-h align-start justify-space-between">
       <result-details class="mt-xl" v-if="itemDetails" :details="itemDetails"/>
-      <related-results v-if="relevant" class="mt-xl" :relevant="relevant" />
+      <related-results class="mt-xl" :relevant="relevant" />
     </div>
-    <base-button class="px-m mt-m" :text="text" @click="$router.push({ name: 'Home' })" />
+    <base-button class="px-m mt-m" text="Go Back" @click="$router.push({ name: 'Home' })" />
   </div>
 </template>
 
@@ -16,10 +16,6 @@ import BaseButton from '../common/BaseButton'
 
 export default {
   name: 'DetailsPanel',
-  data: () => ({
-    name: '',
-    text: 'Go Back'
-  }),
   props: {
     name: {
       type: String,

--- a/starwarsapp/src/components/details/DetialsPanel.vue
+++ b/starwarsapp/src/components/details/DetialsPanel.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="details-panel flex-v align-start justify-space-between box-shadow pa-xl">
+    <span class="name">{{ name }}</span>
+    <div class="details-panel-content flex-h align-start justify-space-between">
+      <result-details class="mt-xl" v-if="itemDetails" :details="itemDetails"/>
+      <related-results v-if="relevant" class="mt-xl" :relevant="relevant" />
+    </div>
+    <base-button class="px-m mt-m" :text="text" @click="$router.push({ name: 'Home' })" />
+  </div>
+</template>
+
+<script>
+import ResultDetails from './ResultDetails'
+import RelatedResults from './RelatedResults'
+import BaseButton from '../common/BaseButton'
+
+export default {
+  name: 'DetailsPanel',
+  data: () => ({
+    name: '',
+    text: 'Go Back'
+  }),
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+    relevant: {
+      type: Array,
+      default: () => ([])
+    },
+    itemDetails: {
+      type: Array,
+      default: () => ([])
+    }
+  },
+  created () {
+    console.log(this.relevant)
+  },
+  components: {
+    ResultDetails,
+    RelatedResults,
+    BaseButton
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.details-panel {
+  width: var(--measure-l);
+  background-color: var(--color-white);
+
+  &-content {
+    width: 100%;
+  }
+
+  .name {
+    font-size: var(--font-size-l)
+  }
+}
+</style>

--- a/starwarsapp/src/components/details/RelatedResult.vue
+++ b/starwarsapp/src/components/details/RelatedResult.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="related-result">
+    <router-link :to="to">{{ title }}</router-link>
+    <span>, </span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'RelateResult',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    link: {
+      type: String,
+      required: true
+    }
+  },
+  computed: {
+    to: vm => `/details${vm.link}`
+  }
+}
+</script>

--- a/starwarsapp/src/components/details/RelatedResults.vue
+++ b/starwarsapp/src/components/details/RelatedResults.vue
@@ -1,12 +1,15 @@
 <template>
   <div class="related-results flex-v align-start">
     <span class="related-results-description mb-l">Related items:</span>
-    <div class="related-results-box flex-h flex-wrap">
+    <div v-if="relevant" class="related-results-box flex-h flex-wrap">
       <related-result
         v-for="[name, url] in relevant"
         :key="url"
         :title="name"
         :link="url" />
+    </div>
+    <div class="loading flex-v justify-center" v-else>
+      <span>Loading...</span>
     </div>
   </div>
 </template>
@@ -19,7 +22,7 @@ export default {
   props: {
     relevant: {
       type: Array,
-      required: true
+      default: null
     }
   },
   components: {
@@ -29,8 +32,16 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.related-results-box {
+.related-results {
   width: 15rem;
-  text-align: justify;
+
+  &-box {
+    text-align: justify;
+  }
+
+  .loading {
+    width: 100%;
+    height: 10.625rem;
+  }
 }
 </style>

--- a/starwarsapp/src/components/details/RelatedResults.vue
+++ b/starwarsapp/src/components/details/RelatedResults.vue
@@ -41,7 +41,11 @@ export default {
 
   .loading {
     width: 100%;
-    height: 10.625rem;
+    margin: 55% 0;
+
+    span {
+      color: var(--color-grey-dimm);
+    }
   }
 }
 </style>

--- a/starwarsapp/src/components/details/RelatedResults.vue
+++ b/starwarsapp/src/components/details/RelatedResults.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="related-results flex-v align-start">
+    <span class="related-results-description mb-l">Related items:</span>
+    <div class="related-results-box flex-h flex-wrap">
+      <related-result
+        v-for="[name, url] in relevant"
+        :key="url"
+        :title="name"
+        :link="url" />
+    </div>
+  </div>
+</template>
+
+<script>
+import RelatedResult from './RelatedResult'
+
+export default {
+  name: 'RelatedResults',
+  props: {
+    relevant: {
+      type: Array,
+      required: true
+    }
+  },
+  components: {
+    RelatedResult
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.related-results-box {
+  width: 15rem;
+  text-align: justify;
+}
+</style>

--- a/starwarsapp/src/components/details/ResultDetail.vue
+++ b/starwarsapp/src/components/details/ResultDetail.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="result-detail flex-h align-center justify-space-between mb-m">
+  <div class="result-detail flex-h align-start justify-space-between mb-m">
     <span class="result-detail-name mr-l">{{ formatedDetailName.replace('_', ' ') }}:</span>
     <span class="result-detail-value">{{ detailValue.replace('_', ' ') }}</span>
   </div>
@@ -35,6 +35,7 @@ export default {
   &-value {
     font-size: var(--font-size-s);
     color: var(--color-grey-dimm);
+    text-align: right;
   }
 }
 </style>

--- a/starwarsapp/src/components/details/ResultDetail.vue
+++ b/starwarsapp/src/components/details/ResultDetail.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="result-detail flex-h align-center justify-space-between mb-m">
+    <span class="result-detail-name mr-l">{{ formatedDetailName.replace('_', ' ') }}:</span>
+    <span class="result-detail-value">{{ detailValue.replace('_', ' ') }}</span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ResultDetail',
+  props: {
+    detailName: {
+      type: String,
+      required: true
+    },
+    detailValue: {
+      type: String,
+      required: true
+    }
+  },
+  computed: {
+    formatedDetailName: vm => vm.detailName.charAt(0).toUpperCase() + vm.detailName.slice(1)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.result-detail {
+  width: 100%;
+
+  &-name {
+    font-size: var(--fonz-size-s);
+  }
+
+  &-value {
+    font-size: var(--font-size-s);
+    color: var(--color-grey-dimm);
+  }
+}
+</style>

--- a/starwarsapp/src/components/details/ResultDetails.vue
+++ b/starwarsapp/src/components/details/ResultDetails.vue
@@ -31,8 +31,6 @@ export default {
 
 <style lang="scss" scoped>
 .result-details {
-  .name {
-    font-size: var(--font-size-l);
-  }
+  max-width: 50%;
 }
 </style>

--- a/starwarsapp/src/components/details/ResultDetails.vue
+++ b/starwarsapp/src/components/details/ResultDetails.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="result-details flex-v align-start justify-center">
+    <span class="details-panel-content-description mb-l">Details:</span>
+    <result-detail
+      v-for="[name, value] in detailsWithoutName"
+      :key="value"
+      :detailName="name"
+      :detailValue="value" />
+  </div>
+</template>
+
+<script>
+import ResultDetail from './ResultDetail'
+
+export default {
+  name: 'ResultDetails',
+  props: {
+    details: {
+      type: Array,
+      required: true
+    }
+  },
+  computed: {
+    detailsWithoutName: vm => vm.details.slice(1)
+  },
+  components: {
+    ResultDetail
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.result-details {
+  .name {
+    font-size: var(--font-size-l);
+  }
+}
+</style>

--- a/starwarsapp/src/components/details/ResultDetails.vue
+++ b/starwarsapp/src/components/details/ResultDetails.vue
@@ -3,7 +3,7 @@
     <span class="details-panel-content-description mb-l">Details:</span>
     <result-detail
       v-for="[name, value] in detailsWithoutName"
-      :key="value"
+      :key="name+value"
       :detailName="name"
       :detailValue="value" />
   </div>

--- a/starwarsapp/src/components/search/SearchResult.vue
+++ b/starwarsapp/src/components/search/SearchResult.vue
@@ -41,11 +41,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-.search-result {
-  &-name {
-    font-size: var(--font-size-l);
-  }
-}
-</style>

--- a/starwarsapp/src/components/search/SearchResult.vue
+++ b/starwarsapp/src/components/search/SearchResult.vue
@@ -33,7 +33,7 @@ export default {
       const place = this.link.search('people')
       return place !== -1
         ? this.link.slice(place, this.link.length)
-        : this.link.slice(place, this.link.length)
+        : this.link.slice(this.link.search('films'), this.link.length)
     }
   },
   components: {

--- a/starwarsapp/src/components/search/SearchResult.vue
+++ b/starwarsapp/src/components/search/SearchResult.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="search-result flex-h align-center justify-space-between mt-m">
     <span class="search-result-name">{{ name }}</span>
-    <base-button class="go-to-details px-m" text="Details"/>
+    <base-button
+     class="go-to-details px-m"
+     text="Details"
+     @click="onClick" />
   </div>
 </template>
 
@@ -20,12 +23,17 @@ export default {
       required: true
     }
   },
+  methods: {
+    onClick () {
+      this.$router.push({ path: `details/${this.url}` })
+    }
+  },
   computed: {
     url () {
       const place = this.link.search('people')
       return place !== -1
-        ? this.link.slice('people'.length + 1, this.link.length)
-        : this.link.slice('moveis'.length + 1, this.link.length)
+        ? this.link.slice(place, this.link.length)
+        : this.link.slice(place, this.link.length)
     }
   },
   components: {

--- a/starwarsapp/src/components/search/SearchResults.vue
+++ b/starwarsapp/src/components/search/SearchResults.vue
@@ -14,10 +14,10 @@
       </div>
       <div class="results" v-if="!hasResults">
         <search-result
-          v-for="result in results"
-          :key="result.name"
-          :name="result.name"
-          :link="result.url" />
+          v-for="{ name, url } in results"
+          :key="name"
+          :name="name"
+          :link="url" />
       </div>
     </div>
   </div>

--- a/starwarsapp/src/components/search/SearchResults.vue
+++ b/starwarsapp/src/components/search/SearchResults.vue
@@ -3,7 +3,7 @@
     <span class="search-results-label">Results</span>
     <hr class="mt-m"/>
     <div class="search-results-field flex-v align-center justify-center">
-      <div v-if="hasResults" class="no-results">
+      <div v-if="!results.length" class="no-results">
         <span>
           There are zero matches.
         </span>
@@ -12,12 +12,21 @@
           Use the form to search for People of Movies.
         </span>
       </div>
-      <div class="results" v-if="!hasResults">
-        <search-result
-          v-for="{ name, url } in results"
-          :key="name"
-          :name="name"
-          :link="url" />
+      <div v-else class="results-wrapper">
+        <div class="results" v-if="!isFilm">
+          <search-result
+            v-for="{ name, url } in results"
+            :key="name"
+            :name="name"
+            :link="url" />
+        </div>
+        <div class="results" v-else>
+          <search-result
+            v-for="{ title, url } in results"
+            :key="title"
+            :name="title"
+            :link="url" />
+      </div>
       </div>
     </div>
   </div>
@@ -32,10 +41,11 @@ export default {
     results: {
       type: Array,
       required: true
+    },
+    isFilm: {
+      type: Boolean,
+      default: false
     }
-  },
-  computed: {
-    hasResults: vm => !vm.results.length
   },
   components: {
     SearchResult
@@ -63,7 +73,7 @@ export default {
       }
     }
 
-    .results {
+    .results-wrapper {
       width: 100%;
       height: 100%;
     }

--- a/starwarsapp/src/router/index.js
+++ b/starwarsapp/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from '../views/Home.vue'
+import Details from '../views/Details.vue'
 
 Vue.use(VueRouter)
 
@@ -11,12 +12,9 @@ const routes = [
     component: Home
   },
   {
-    path: '/about',
-    name: 'About',
-    // route level code-splitting
-    // this generates a separate chunk (about.[hash].js) for this route
-    // which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "about" */ '../views/About.vue')
+    path: '/details/:type/:id',
+    name: 'Details',
+    component: Details
   }
 ]
 

--- a/starwarsapp/src/views/About.vue
+++ b/starwarsapp/src/views/About.vue
@@ -1,5 +1,0 @@
-<template>
-  <div class="about">
-    <h1>This is an about page</h1>
-  </div>
-</template>

--- a/starwarsapp/src/views/Details.vue
+++ b/starwarsapp/src/views/Details.vue
@@ -2,7 +2,11 @@
   <div class="details">
     <app-header />
     <div class="content flex-h align-center justify-center my-xl">
-      <details-panel />
+      <details-panel
+        v-if="relevant"
+        :name="name"
+        :relevant="relevant"
+        :item-details="itemDetails" />
     </div>
   </div>
 </template>
@@ -10,9 +14,91 @@
 <script>
 import AppHeader from '@/components/AppHeader'
 import DetailsPanel from '@/components/details/DetialsPanel.vue'
+import api from '@/api/search.js'
+import shuffle from 'lodash.shuffle'
+import searchOptions from '@/config/searchOptions.js'
+const { PEOPLE } = searchOptions
 
 export default {
   name: 'Details',
+  data: () => ({
+    name: '',
+    relevant: null,
+    itemDetails: null
+  }),
+  methods: {
+    async getDetails ({ type, id }) {
+      const { data } = type.toUpperCase() === PEOPLE
+        ? await api.getPeopleById(id)
+        : await api.getMoviesById(id)
+      const array = Object.keys(data).map(key => ([key, data[key]])).splice(0, 13)
+      const [name, ...rest] = array.slice(0, 8)
+      this.name = name[1]
+      this.itemDetails = rest
+      let relevant = array.slice(8)
+      relevant = await this.formatRelevant(relevant)
+      let relevantOnceRemoved = await this.getRelevantForPeople(relevant)
+      relevantOnceRemoved = shuffle(relevantOnceRemoved)
+      this.relevant = relevantOnceRemoved.slice(0, 15)
+    },
+    generatePath (url) {
+      return url.slice(url.search('/api') + '/api'.length)
+    },
+    isFilmOrPlanet (url) {
+      return url.search('films') !== -1 || url.search('planets') !== -1
+    },
+    async formatRelevant (relevant) {
+      const urls = []
+      for (const [, value] of relevant) {
+        if (typeof value === 'string') urls.push(value)
+        else {
+          for (const insance of value) urls.push(insance)
+        }
+      }
+      return await Promise.all(urls.map(async url => {
+        const key = url.search('films') !== -1
+          ? 'title'
+          : 'name'
+        const { data } = await api.get(this.generatePath(url))
+        return [data[key], this.generatePath(url)]
+      }))
+    },
+    async getRelevantForPeople (relevant) {
+      const [homeworld, ...rest] = relevant
+      const dontGetRelevant = []
+      const { data: { residents } } = await api.get(homeworld[1])
+      const charUrls = residents.slice(0, 4)
+      for (const [name, url] of rest) {
+        if (this.isFilmOrPlanet(url)) {
+          const { data: { characters } } = await api.get(url)
+          let i = 0
+          for (const character of characters) {
+            if (!charUrls.includes(character) && i < 4) {
+              charUrls.push(character)
+              i++
+            }
+          }
+        } else dontGetRelevant.push([name, url])
+      }
+      const chars = await Promise.all(charUrls.map(async charUrl => {
+        const { data: { name } } = await api.get(charUrl)
+        return [name, this.generatePath(charUrl)]
+      }))
+      return chars.concat(dontGetRelevant)
+    }
+  },
+  watch: {
+    $route: {
+      async handler ({ params }) {
+        await this.getDetails(params)
+        this.$forceUpdate()
+      }
+    }
+  },
+  async created () {
+    console.log('created')
+    await this.getDetails(this.$route.params)
+  },
   components: {
     AppHeader,
     DetailsPanel

--- a/starwarsapp/src/views/Details.vue
+++ b/starwarsapp/src/views/Details.vue
@@ -3,7 +3,6 @@
     <app-header />
     <div class="content flex-h align-center justify-center my-xl">
       <details-panel
-        v-if="relevant"
         :name="name"
         :relevant="relevant"
         :item-details="itemDetails" />
@@ -31,6 +30,8 @@ export default {
       const { data } = type.toUpperCase() === PEOPLE
         ? await api.getPeopleById(id)
         : await api.getMoviesById(id)
+      if (this.relevant !== null) this.relevant = null
+      if (this.itemDetails !== null) this.itemDetails = null
       const array = Object.keys(data).map(key => ([key, data[key]])).splice(0, 13)
       const [name, ...rest] = array.slice(0, 8)
       this.name = name[1]

--- a/starwarsapp/src/views/Details.vue
+++ b/starwarsapp/src/views/Details.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="details">
+    <app-header />
+    <div class="content flex-h align-center justify-center my-xl">
+      <details-panel />
+    </div>
+  </div>
+</template>
+
+<script>
+import AppHeader from '@/components/AppHeader'
+import DetailsPanel from '@/components/details/DetialsPanel.vue'
+
+export default {
+  name: 'Details',
+  components: {
+    AppHeader,
+    DetailsPanel
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.details {
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  background-color: var(--color-grey-light);
+
+  .content {
+    width: 100%;
+  }
+}
+</style>

--- a/starwarsapp/src/views/Details.vue
+++ b/starwarsapp/src/views/Details.vue
@@ -184,7 +184,6 @@ export default {
         }
         return [name, this.generatePath(url)]
       }))
-      console.log(chars, dontGetRelevant)
       return this.checkForTheSame(chars, dontGetRelevant)
     }
   },

--- a/starwarsapp/src/views/Home.vue
+++ b/starwarsapp/src/views/Home.vue
@@ -3,7 +3,7 @@
     <app-header />
     <div class="content flex-h align-start justify-center my-xl">
       <search-options class="mr-xl" @search="search" :button-text="searchButtonText" />
-      <search-results :results="results" />
+      <search-results :results="results" :isFilm="isFilm" />
     </div>
   </div>
 </template>
@@ -20,15 +20,21 @@ export default {
   name: 'Home',
   data: () => ({
     results: [],
+    isFilm: false,
     searchButtonText: 'Search'
   }),
   methods: {
     async search ({ picked: type, value: name }) {
       this.searchButtonText = 'Searching...'
-      const { data: { results } } = type === PEOPLE
-        ? await api.getPeopleByName(name)
-        : await api.getMoviesByName(name)
-      this.results = results
+      if (type === PEOPLE) {
+        const { data: { results } } = await api.getPeopleByName(name)
+        this.isFilm = false
+        this.results = results
+      } else {
+        const { data: { results } } = await api.getMoviesByName(name)
+        this.isFilm = true
+        this.results = results
+      }
       this.searchButtonText = 'Search'
     }
   },

--- a/starwarsapp/src/views/Home.vue
+++ b/starwarsapp/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="home">
     <app-header />
     <div class="content flex-h align-start justify-center my-xl">
       <search-options class="mr-xl" @search="search" :button-text="searchButtonText" />
@@ -39,7 +39,7 @@ export default {
 </script>
 
 <style lang="scss">
-#app {
+#home {
   width: 100%;
   height: 100%;
   text-align: center;

--- a/starwarsapp/src/views/Home.vue
+++ b/starwarsapp/src/views/Home.vue
@@ -25,7 +25,9 @@ export default {
   methods: {
     async search ({ picked: type, value: name }) {
       this.searchButtonText = 'Searching...'
-      const { data: { results } } = type === PEOPLE ? await api.getPerson(name) : await api.getMovies(name)
+      const { data: { results } } = type === PEOPLE
+        ? await api.getPeopleByName(name)
+        : await api.getMoviesByName(name)
       this.results = results
       this.searchButtonText = 'Search'
     }


### PR DESCRIPTION
- Added details panel with item details and relevant items
- Added button for returning to the home page
- Added loading text that shows when relevant items are loaded
- Relevant items lead to the relevant item details
- Items that are type film have their opening scrawl above the details and relevant items

Details display for films:

![Films details](https://user-images.githubusercontent.com/49108092/98691094-f2645080-236d-11eb-9f13-5b28df4d68e0.JPG)

Details display for other items:

![Other details](https://user-images.githubusercontent.com/49108092/98691132-fee8a900-236d-11eb-95b4-e580a12e5ffc.JPG)
